### PR TITLE
add roboto font, preflight header styles

### DIFF
--- a/app/contact/page.js
+++ b/app/contact/page.js
@@ -17,7 +17,7 @@ export default function Contact() {
          content: (
             <>
                <div>
-                  <h5 className="font-bold mb-8 text-lg">+1 818 854-5273</h5>
+                  <h5 className="mb-8">+1 818 854-5273</h5>
                   <p className="">We are available 9:00 AM - 4 PM PST</p>
                </div>
             </>
@@ -30,14 +30,12 @@ export default function Contact() {
             <>
                <div className="flex flex-col space-y-8">
                   <div>
-                     <h5 className="font-bold text-lg">
-                        General/Administrative
-                     </h5>
+                     <h5>General/Administrative</h5>
                      <p>admin@itisoverdue.org</p>
                   </div>
 
                   <div>
-                     <h5 className="font-bold text-lg">Education</h5>
+                     <h5>Education</h5>
                      <p>education@itisoverdue.org</p>
                   </div>
                </div>
@@ -83,11 +81,9 @@ export default function Contact() {
          >
             {/* Title, Accent Line, Subheader */}
             <>
-               <h2 className="text-4xl md:text-5xl font-bold">IT IS OVERDUE</h2>
+               <h2>IT IS OVERDUE</h2>
                <div className="border-t-8 border-primary w-20 rounded-full my-4 md:my-5 md:w-28" />
-               <h3 className="text-xl md:text-2xl font-bold">
-                  We are a team based in Woodland Hills, CA.
-               </h3>
+               <h3>We are a team based in Woodland Hills, CA.</h3>
             </>
 
             {/* Cards */}
@@ -114,7 +110,7 @@ const ContactCard = ({ icon, header, content }) => {
             <span className="w-16 h-16 bg-primary  rounded-full p-4 text-darker-grey block mx-auto mb-3">
                {icon}
             </span>
-            <h4 className="text-2xl font-bold">{header}</h4>
+            <h4>{header}</h4>
          </div>
 
          {/* Content */}

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,40 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+   /* 
+   
+   Tailwind / Roboto font weights
+   
+   font-thin: 100
+   font-light: 300
+   font-normal: 400
+   font-medium: 500
+   font-bold: 700
+   font-black: 900
+   
+   */
+
+   h1 {
+      @apply text-6xl md:text-7xl font-bold text-primary capitalize;
+   }
+   h2 {
+      @apply text-4xl md:text-5xl font-bold;
+   }
+   h3 {
+      @apply text-xl md:text-2xl font-bold;
+   }
+   h4 {
+      @apply text-2xl font-bold;
+   }
+   h5 {
+      @apply text-lg font-bold;
+   }
+   h6 {
+      @apply text-2xl font-medium;
+   }
+}
+
 * {
    box-sizing: border-box;
    padding: 0;

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,8 +1,15 @@
+import { Roboto } from "next/font/google"
+
 import "./globals.css"
-import { Inter } from "next/font/google"
 import Header from "@/components/Layout/Header"
 import Footer from "@/components/Layout/Footer"
-const inter = Inter({ subsets: ["latin"] })
+
+const roboto = Roboto({
+   weight: ["100", "300", "400", "500", "700", "900"],
+   style: ["normal", "italic"],
+   subsets: ["latin"],
+   display: "swap",
+})
 
 export const metadata = {
    title: "Create Next App",
@@ -12,7 +19,7 @@ export const metadata = {
 export default function RootLayout({ children }) {
    return (
       <html lang="en">
-         <body className={inter.className}>
+         <body className={roboto.className}>
             <Header />
             <main>{children}</main>
             <Footer />

--- a/components/Layout/Footer/index.js
+++ b/components/Layout/Footer/index.js
@@ -162,7 +162,7 @@ export default function Footer() {
 
             {/* Quick Links */}
             <div className="">
-               <h6 className="mb-8 text-2xl font-medium w-max">Quick Links</h6>
+               <h6 className="mb-8 w-max">Quick Links</h6>
                <ul className="space-y-4  w-max">
                   {quickLinks.map((item) => (
                      <li key={item.text}>
@@ -179,7 +179,7 @@ export default function Footer() {
 
             {/* Contact Us */}
             <div>
-               <h6 className="mb-8 text-2xl font-medium">Contact Us</h6>
+               <h6 className="mb-8">Contact Us</h6>
                <ul className="space-y-4">
                   {contactUs.map((item) => (
                      <li
@@ -238,9 +238,7 @@ export default function Footer() {
                      </defs>
                   </svg>
                   {/* Header */}
-                  <h6 className="text-2xl font-semibold ml-4">
-                     Join Our Team!
-                  </h6>
+                  <h6 className="ml-4">Join Our Team!</h6>
                </div>
 
                {/* Subheader */}
@@ -251,7 +249,7 @@ export default function Footer() {
 
                {/* Sign Up Link */}
                <Link href="https://www.itisoverdue.org/joinus/">
-                  <button className="bg-primary w-full py-4 font-semibold rounded-md transition-colors duration-300 hover:bg-darkest-grey hover:text-primary">
+                  <button className="bg-primary w-full py-4 font-medium rounded-md transition-colors duration-300 hover:bg-darkest-grey hover:text-primary">
                      Sign Up Now!
                   </button>
                </Link>

--- a/components/shared/PageHero.js
+++ b/components/shared/PageHero.js
@@ -10,13 +10,13 @@ export default function PageHero({ page, backgroundImageSrc = "" }) {
          childSx="flex justify-center items-center h-full relative"
       >
          {/* Header w/ underline */}
-         <h1 className="text-6xl md:text-7xl font-bold text-primary capitalize">
+         <h1>
             {page}
             <span className="mt-2 block w-1/3 border-t-8 border-primary rounded-2xl mx-auto" />
          </h1>
 
          {/* Breadcrumbs: Home --> {page} */}
-         <div className="absolute left-3 -bottom-6 flex item-center space-x-3 text-white bg-darker-grey px-5 py-4 rounded-xl font-semibold shadow-md">
+         <div className="absolute left-3 -bottom-6 flex item-center space-x-3 text-white bg-darker-grey px-5 py-4 rounded-xl font-medium shadow-md">
             <Link
                href="/"
                className="hover:text-primary transition-colors duration-200"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,38 +1,34 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: [
-    "./app/**/*.{js,ts,jsx,tsx,mdx}",
-    "./pages/**/*.{js,ts,jsx,tsx,mdx}",
-    "./components/**/*.{js,ts,jsx,tsx,mdx}",
-  ],
-  theme: {
-    extend: {
-      colors: {
-        // black to white
-        black: '#000',
-        'darkest-grey': '#111',
-        'darker-grey': '#222',
-        'dark-grey': '#333',
-        grey: '#666',
-        'light-grey': '#999',
-        'lighter-grey': '#ccc',
-        'lightest-grey': '#eee',
-        white: '#fff',
+   content: [
+      "./app/**/*.{js,ts,jsx,tsx,mdx}",
+      "./pages/**/*.{js,ts,jsx,tsx,mdx}",
+      "./components/**/*.{js,ts,jsx,tsx,mdx}",
+   ],
+   theme: {
+      extend: {
+         colors: {
+            // black to white
+            black: "#000",
+            "darkest-grey": "#111",
+            "darker-grey": "#222",
+            "dark-grey": "#333",
+            grey: "#666",
+            "light-grey": "#999",
+            "lighter-grey": "#ccc",
+            "lightest-grey": "#eee",
+            white: "#fff",
 
-        // brand colors
-        primary: '#fdd92a',
-        primaryDark: '#ffc107',
-        background: '#f6f5f2',
+            // brand colors
+            primary: "#fdd92a",
+            primaryDark: "#ffc107",
+            background: "#f6f5f2",
 
-        // status colors
-        error: '#e84118',
-        success: '#009432',
+            // status colors
+            error: "#e84118",
+            success: "#009432",
+         },
       },
-      fontFamily: {
-        'sans': ['Roboto', 'sans-serif'], 
-      },
-    },
-  },
-  plugins: [],
+   },
+   plugins: [],
 }
-


### PR DESCRIPTION
- changes `next/font` import from `Inter` to `Roboto`
- adds configurations for **Roboto** font
- replaces `Inter` with `Roboto` in body class
- adds preflight styles for `h1`, `h2`, `h3`, `h4`, `h5`, and `h6` classes in **globals.css** file
- removes redundant inline header styles (styles specific to an element unchanged)
- updates undefined `semibold` (600)(not available in Roboto) font weight style to `medium` (500) 