### PR TITLE
💄 Restyled - Added 3 Columns on lg screens

### DIFF
--- a/app/education/page.js
+++ b/app/education/page.js
@@ -191,7 +191,7 @@ const EventCard = ({ image, aspect, title, text }) => {
             alt={title}
             fill
             style={{ objectFit: "cover" }}
-            sizes="(min-width: 768px) 50vw, 100vw"
+            sizes="(min-width: 768px) 30vw, 100vw"
          />
 
          {/* Title, Text */}


### PR DESCRIPTION
- Restyled to have 3 columns instead of 2 columns
- Cards were too big on 2 columns