### PR TITLE
:bug: fix carousel image load, :bento: new image links, :lipstick: ad…

### DIFF
--- a/app/about/page.js
+++ b/app/about/page.js
@@ -7,6 +7,7 @@ import Button from "@/components/shared/Button"
 import WhatWeDo from "@/components/Pages/WhatWeDo"
 import WaysToHelp from "@/components/Pages/WaysToHelp"
 import SectionSubheader from "@/components/Pages/SectionSubheader"
+import MembersCarousel from "@/components/shared/MembersCarousel"
 
 export default function About() {
    return (
@@ -142,6 +143,8 @@ export default function About() {
             {/* WAYS TO HELP */}
             <WaysToHelp />
 
+               {/* OUR MEMBERS */}
+            <MembersCarousel />
             {/* GET IN TOUCH */}
             <section className="mx-auto mt-24">
                <div className="flex flex-col justify-center text-center xl:px-12">

--- a/app/page.js
+++ b/app/page.js
@@ -4,7 +4,6 @@ import Card from "@/components/shared/Card"
 import FullBleedContainer from "@/components/Layout/Container/FullBleedContainer"
 import Button from "@/components/shared/Button"
 import EffortStats from "@/components/Landing/EffortStats"
-import MembersCarousel from "@/components/shared/MembersCarousel"
 import SectionSubheader from "@/components/Pages/SectionSubheader"
 import WhatWeDo from "@/components/Pages/WhatWeDo"
 import WaysToHelp from "@/components/Pages/WaysToHelp"
@@ -78,7 +77,6 @@ export default function Home() {
             {/* Our Partners section */}
             {/* Become a Sponsor section */}
             {/* Subscribe to Newsletter section */}
-            <MembersCarousel />
          </FullBleedContainer>
       </main>
    )

--- a/components/shared/MembersCarousel.js
+++ b/components/shared/MembersCarousel.js
@@ -17,7 +17,7 @@ export default function MembersCarousel() {
    // State variables
    const [currentIndex, setCurrentIndex] = useState(0)
    const [isPlaying, setIsPlaying] = useState(true)
-   const ITEM_WIDTH = 260 // 250px width + 10px right padding
+   const ITEM_WIDTH = 310 // 250px width + 10px right padding
 
    // Navigate to the next item
    function next() {
@@ -53,16 +53,25 @@ export default function MembersCarousel() {
                   className="flex-none"
                   style={{ width: `${ITEM_WIDTH}px` }}
                >
-                  <Image
+                  {/* 
+                     // Image component has a bug when scroll load in this carousel, so we use <img> instead
+                  <Image                            
                      src={item.profile}
                      alt={item.name}
                      className="rounded-3xl object-cover"
                      width={250}
                      height={333}
                      quality={50}
+                  /> */}
+                  <img 
+                     src={item.profile}
+                     alt={item.name}
+                     className="rounded-3xl"
+                     width={300}
+                     height={350}
                   />
-                  <h3 className="text-dark-grey">{item.name}</h3>
-                  <div className="font-regular max-w-[235px] text-sm">
+                  <h3 className="text-dark-grey pt-4">{item.name}</h3>
+                  <div className="font-regular max-w-[280px] text-sm ">
                      <p className="text-grey">{item.designation}</p>
                      <p className="text-light-grey">{item.location}</p>
                   </div>

--- a/lib/data.js
+++ b/lib/data.js
@@ -54,7 +54,7 @@ export const SUPPORTERS = [
       id: 2,
       name: "Alma Leon",
       profile:
-         "https://res.cloudinary.com/di7ejl8jx/image/upload/v1688441388/supporters/2_l1x1df.jpg",
+         "https://res.cloudinary.com/di7ejl8jx/image/upload/v1693523854/2_l1x1df_cii719.jpg",
       designation: "Board Member / Event Coordinator / Community Garden",
       location: "California, USA",
    },
@@ -62,7 +62,7 @@ export const SUPPORTERS = [
       id: 3,
       name: "Anna D'arcy",
       profile:
-         "https://res.cloudinary.com/di7ejl8jx/image/upload/v1688441389/supporters/3_g6iak5.jpg",
+         "https://res.cloudinary.com/di7ejl8jx/image/upload/v1693523855/3_g6iak5_dtw2pz.jpg",
       designation: "Board Member / Website Content Manager",
       location: "California, USA",
    },
@@ -70,7 +70,7 @@ export const SUPPORTERS = [
       id: 4,
       name: "Egor Chumak",
       profile:
-         "https://res.cloudinary.com/di7ejl8jx/image/upload/v1688441389/supporters/4_fzo7tt.jpg",
+         "https://res.cloudinary.com/di7ejl8jx/image/upload/v1693523856/4_fzo7tt_mv3oy6.jpg",
       designation: "Board Member / LA River Project / Earth Day",
       location: "California, USA",
    },
@@ -78,7 +78,7 @@ export const SUPPORTERS = [
       id: 5,
       name: "Igor Leontiy & Ace",
       profile:
-         "https://res.cloudinary.com/di7ejl8jx/image/upload/v1688441390/supporters/5_kfkqpg.jpg",
+         "https://res.cloudinary.com/di7ejl8jx/image/upload/v1693523857/5_kfkqpg_iz8pan.jpg",
       designation: "Board Member and Sr. Vice Pawresident",
       location: "California, USA",
    },
@@ -86,7 +86,7 @@ export const SUPPORTERS = [
       id: 6,
       name: "Sean",
       profile:
-         "https://res.cloudinary.com/di7ejl8jx/image/upload/v1688441390/supporters/6_ivsnxl.jpg",
+         "https://res.cloudinary.com/di7ejl8jx/image/upload/v1693523858/6_ivsnxl_nclrws.jpg",
       designation: "Board Member / Education Coordinator",
       location: "California, USA",
    },
@@ -94,7 +94,7 @@ export const SUPPORTERS = [
       id: 7,
       name: "Lily Rui",
       profile:
-         "https://res.cloudinary.com/di7ejl8jx/image/upload/v1688441390/supporters/7_kmcy7t.jpg",
+         "https://res.cloudinary.com/di7ejl8jx/image/upload/v1693523859/7_kmcy7t_lza8wa.jpg",
       designation:
          "Board Member / Education / International Relation / Community Outreach",
       location: "California, USA",
@@ -103,7 +103,7 @@ export const SUPPORTERS = [
       id: 8,
       name: "Max & Leon",
       profile:
-         "https://res.cloudinary.com/di7ejl8jx/image/upload/v1688441390/supporters/8_vgnfmn.jpg",
+         "https://res.cloudinary.com/di7ejl8jx/image/upload/v1693523861/8_vgnfmn_zkrcgc.jpg",
       designation: "CEO and Chief Paw Officer",
       location: "California, USA",
    },
@@ -111,7 +111,7 @@ export const SUPPORTERS = [
       id: 10,
       name: "Samantha Evans",
       profile:
-         "https://res.cloudinary.com/di7ejl8jx/image/upload/v1688441389/supporters/10_ednydv.jpg",
+         "https://res.cloudinary.com/di7ejl8jx/image/upload/v1693523862/10_ednydv_xyyn9l.jpg",
       designation: "Board Member / Community Outreach",
       location: "California, USA",
    },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5854,9 +5854,9 @@
           }
         },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         }
       }
     },
@@ -5884,9 +5884,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         }
       }
     },
@@ -5931,9 +5931,9 @@
           }
         },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         }
       }
     },
@@ -6999,6 +6999,11 @@
         "p-limit": "^3.0.2"
       }
     },
+    "papaparse": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.4.1.tgz",
+      "integrity": "sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw=="
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7186,6 +7191,12 @@
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
       }
+    },
+    "react-intersection-observer": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.5.2.tgz",
+      "integrity": "sha512-EmoV66/yvksJcGa1rdW0nDNc4I1RifDWkT50gXSFnPLYQ4xUptuDD4V7k+Rj1OgVAlww628KLGcxPXFlOkkU/Q==",
+      "requires": {}
     },
     "react-is": {
       "version": "16.13.1",
@@ -7892,9 +7903,9 @@
       }
     },
     "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="
     },
     "wrappy": {
       "version": "1.0.2",


### PR DESCRIPTION
- There is a bug when using , it loads the images stretched on the right side of the carousel before coming into view. I switched to a regular  and it works well now.
- I also resized and cropped member images to from 250w to 300x350.
- Carousel code reflects this change of resize.
- Member details text has better styling to match Figma design.
- add Members Carousel to About Us page and remove from Home