### PR TITLE
141 add bay area to map

### DIFF
--- a/app/events/page.js
+++ b/app/events/page.js
@@ -53,9 +53,9 @@ const chapters = [
       zIndex: "z-[10]",
    },
    {
-      location: "San Francisco Bay Area, CA",
-      lat: "left-[13%]",
-      lon: "top-[23%]",
+      location: "Bay Area, CA",
+      lat: "left-[15%]",
+      lon: "top-[33%]",
       zIndex: "z-[10]",
    }
 ]

--- a/app/events/page.js
+++ b/app/events/page.js
@@ -52,6 +52,12 @@ const chapters = [
       lon: "top-[33%]",
       zIndex: "z-[10]",
    },
+   {
+      location: "San Francisco Bay Area, CA",
+      lat: "left-[13%]",
+      lon: "top-[23%]",
+      zIndex: "z-[10]",
+   }
 ]
 
 export default function Events() {

--- a/lib/data.js
+++ b/lib/data.js
@@ -47,6 +47,12 @@ export const LOCATIONS = {
       newsletter:
          "https://843e142f.sibforms.com/serve/MUIEAD1te_sGXPbIeo53AJanGgjPQObZLGZ459mtNcMoggGUhmojyVesn8G0qIIAanjkz5oUjaBGIdzhOH4NRM1GyqZfkcPWRXe2okuelQkdaJVgO2BjLrd6Yq0zbRMzgD_qh67FuAqh3QU3JsUdvwMKEAOaso-Gd_SoeZWl0l82CZJ1VbPpScWjZbhBomFQKpZs6ZXiPD0rDSXW",
    },
+   "Bay Area, CA": {
+      lat: 37.774929,
+      lon: -122.419418,
+      newsletter:
+         "",
+   },
 }
 
 export const SUPPORTERS = [


### PR DESCRIPTION
### New Location Addition

---

**Title: Exciting Expansion: New Bay Area Location Added to Our Events Page**

**Date: 7/31/2024**

We are thrilled to announce the latest enhancement to our events page! As part of our ongoing commitment to providing a comprehensive and engaging user experience, we have added a new location to our list of chapters: the vibrant and innovative Bay Area, CA. 

**Details of the Update:**

**Changes Made:**
1. **File:** `app/events/page.js`
   - **Lines Added:** 
     ```javascript
     {
        location: "Bay Area, CA",
        lat: "left-[15%]",
        lon: "top-[33%]",
        zIndex: "z-[10]",
     }
     ```

2. **File:** `lib/data.js`
   - **Lines Added:** 
     ```javascript
     "Bay Area, CA": {
        lat: 37.774929,
        lon: -122.419418,
        newsletter: "",
     },
     ```

**Impact of the Update:**

The addition of the Bay Area location reflects our dedication to expanding our reach and connecting with more communities. The Bay Area, known for its dynamic culture and tech innovation, is a perfect addition to our events lineup. Users can now easily find and attend events in this bustling region, further enhancing their experience with our platform.

**Looking Ahead:**

We believe this update will significantly benefit our users by providing more opportunities for engagement and participation in various events. 
